### PR TITLE
https-dns-proxy: correct duplicate nft rules and error tracking

### DIFF
--- a/files/etc/init.d/https-dns-proxy
+++ b/files/etc/init.d/https-dns-proxy
@@ -145,13 +145,11 @@ notrack_nft() {
 				return
 			fi
 			new_content="$(cat <<-EOF
-				table inet https_dns_proxy_notrack {
-					chain raw_output {
-						type filter hook output priority raw; policy accept;
-						meta l4proto { tcp, udp } th dport { ${port_set} } ip daddr 127.0.0.0/8 notrack
-						meta l4proto { tcp, udp } th sport { ${port_set} } ip saddr 127.0.0.0/8 notrack
-					}
-				}
+				add table inet https_dns_proxy_notrack
+				flush table inet https_dns_proxy_notrack
+				add chain inet https_dns_proxy_notrack raw_output { type filter hook output priority raw; policy accept; }
+				add rule inet https_dns_proxy_notrack raw_output meta l4proto { tcp, udp } th dport { ${port_set} } ip daddr 127.0.0.0/8 notrack
+				add rule inet https_dns_proxy_notrack raw_output meta l4proto { tcp, udp } th sport { ${port_set} } ip saddr 127.0.0.0/8 notrack
 			EOF
 			)"
 			existing_content="$(cat "$NOTRACK_NFT_FILE" 2>/dev/null)"
@@ -425,7 +423,7 @@ stop_service() {
 		uci_commit 'dhcp'
 		dnsmasq_restart || _error=1
 	fi
-	notrack_nft remove
+	notrack_nft remove || _error=1
 # shellcheck disable=SC2015
 	[ -z "$_error" ] && output_okn || output_failn
 }


### PR DESCRIPTION
Refactor https-dns-proxy init script for nftables
The problem from issue https://github.com/mossdef-org/https-dns-proxy/issues/7 is solved 👍 

Some small remaining things:
Every time the firewall restarts there are duplicate nft rules.

A better approach might be to add the table and then flush it.

Furthermore seeing line https://github.com/mossdef-org/https-dns-proxy/blob/64d18e172fbbe79ee1695bcf32e62658f700c7c1/files/etc/init.d/https-dns-proxy#L166 makes me think you have added it for error tracking?

In that case you might need to add code when that is called see my last proposed change

Signed-off-by: Erik Conijn <egc112@msn.com>