### PR TITLE
https-dns-proxy: ignore disabled dnsmasq DNS port

### DIFF
--- a/files/etc/init.d/https-dns-proxy
+++ b/files/etc/init.d/https-dns-proxy
@@ -461,7 +461,8 @@ dnsmasq_instance_append_force_dns_port() {
 	local cfg="$1" instance_port
 	[ "$(uci_get 'dhcp' "$cfg")" = "dnsmasq" ] || return 1
 	config_get instance_port "$cfg" 'port' '53'
-		str_contains_word "$force_dns_port" "$instance_port" || force_dns_port="${force_dns_port:+${force_dns_port} }${instance_port}"
+	[ "$instance_port" = "0" ] && return 0
+	str_contains_word "$force_dns_port" "$instance_port" || force_dns_port="${force_dns_port:+${force_dns_port} }${instance_port}"
 }
 
 dnsmasq_doh_server() {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -505,6 +505,11 @@ force_dns_port="53 853"
 dnsmasq_instance_append_force_dns_port "cfg01"
 assert_eq "append_force_dns_port: already present port 53 not duplicated" "53 853" "$force_dns_port"
 
+uci_set "dhcp" "cfg03" ".type" "dnsmasq"
+uci_set "dhcp" "cfg03" "port" "0"
+dnsmasq_instance_append_force_dns_port "cfg03"
+assert_eq "append_force_dns_port: disabled dnsmasq port 0 ignored" "53 853" "$force_dns_port"
+
 uci_set "dhcp" "cfg02" ".type" "dnsmasq"
 uci_set "dhcp" "cfg02" "port" "5353"
 dnsmasq_instance_append_force_dns_port "cfg02"


### PR DESCRIPTION
When `dnsmasq` is configured with `option port '0'`, its DNS listener is disabled. However, `https-dns-proxy` still collected that value when building `force_dns_port`.

That caused firewall rules to be generated for invalid destination port `0`.

This change skips disabled `dnsmasq` DNS ports when collecting ports for `force_dns_port`, so only actual listening DNS ports are used.

A regression test is also added to make sure `port 0` is ignored.
