### PR TITLE
https-dns-proxy: Add IPv6 addresses to bootstrap DNS options

### DIFF
--- a/files/etc/config/https-dns-proxy
+++ b/files/etc/config/https-dns-proxy
@@ -24,11 +24,11 @@ config main 'config'
 	option listen_addr '127.0.0.1'
 
 config https-dns-proxy
-	option bootstrap_dns '1.1.1.1,1.0.0.1'
+	option bootstrap_dns '1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001'
 	option resolver_url 'https://cloudflare-dns.com/dns-query'
 	option listen_port '5053'
 
 config https-dns-proxy
-	option bootstrap_dns '8.8.8.8,8.8.4.4'
+	option bootstrap_dns '8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844'
 	option resolver_url 'https://dns.google/dns-query'
 	option listen_port '5054'


### PR DESCRIPTION
The Makefile release is not bumped yet, awaiting possible other enhancements